### PR TITLE
initial attempt at handling existing secrets

### DIFF
--- a/templates/cache/redis-secret.yml
+++ b/templates/cache/redis-secret.yml
@@ -1,3 +1,5 @@
+{{- $existingSecret := include "thingsboard.existingSecrets" . | fromYaml | default dict }}
+{{- if not (hasKey $existingSecret "- name: REDIS_PASSWORD") }}
 {{- $namespace := .Release.Namespace -}}
   {{- $releaseName := .Release.Name }}
   {{- if or (or .Values.internalRedis.enabled .Values.internalRedisCluster.enabled) (or .Values.externalRedis.enabled .Values.installation.msa) }}
@@ -9,4 +11,5 @@ metadata:
 type: Opaque
 data:
   {{- include "thingboard.redis.password" . }}
-  {{- end}}
+  {{- end }}
+{{- end }}

--- a/templates/database/cassandra/cassandra-sercret.yml
+++ b/templates/database/cassandra/cassandra-sercret.yml
@@ -1,3 +1,5 @@
+{{- $existingSecret := include "thingsboard.existingSecrets" . | fromYaml | default dict }}
+{{- if not (hasKey $existingSecret "CASSANDRA_PASSWORD") }}
 {{- $namespace := .Release.Namespace -}}
   {{- $releaseName := .Release.Name }}
 {{- if or .Values.externalCassandra.enabled .Values.internalCassandra.enabled }}
@@ -13,4 +15,5 @@ data:
   {{- else}}
   CASSANDRA_PASSWORD: {{ .Values.externalCassandra.password | b64enc }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/database/psql/postgres-secret.yml
+++ b/templates/database/psql/postgres-secret.yml
@@ -1,3 +1,5 @@
+{{- $existingSecret := include "thingsboard.existingSecrets" . | fromYaml | default dict }}
+{{- if not (hasKey $existingSecret "SPRING_DATASOURCE_PASSWORD") }}
 {{- $namespace := .Release.Namespace -}}
   {{- $releaseName := .Release.Name }}
 apiVersion: v1
@@ -12,3 +14,4 @@ data:
   {{- else }}
   SPRING_DATASOURCE_PASSWORD: {{ .Values.externalPostgresql.password | b64enc }}
   {{- end }}
+{{- end }}

--- a/templates/install/post-install-job.yaml
+++ b/templates/install/post-install-job.yaml
@@ -42,6 +42,8 @@ spec:
         - name: LOAD_DEMO
           value: "true"
         {{- end }}
+      env:
+        {{- include "thingsboard.existingSecrets" . | indent 12 }}
       envFrom:
         {{- include "thingboard.cassandra.configuration.ref" . | indent 12 }}
         {{- include "thingboard.postgres.configuration.ref" . | indent 12 }}

--- a/templates/node/monolith/node-statefulset.yml
+++ b/templates/node/monolith/node-statefulset.yml
@@ -66,6 +66,7 @@ spec:
               value: "monolith"
             - name: HTTP_LOG_CONTROLLER_ERROR_STACK_TRACE
               value: "false"
+            {{- include "thingsboard.existingSecrets" . | indent 12 }}
           envFrom:
             - configMapRef:
                 name: {{$releaseName}}-node-custom-env
@@ -74,6 +75,7 @@ spec:
             {{- include "thingboard.cache.configuration.ref" . | indent 12 }}
             {{- include "thingboard.cassandra.configuration.ref" . | indent 12 }}
             {{- include "thingboard.postgres.configuration.ref" . | indent 12 }}
+
           readinessProbe:
             {{- .Values.node.readinessProbe | toYaml | nindent 12 }}
           livenessProbe:

--- a/templates/node/msa/core-statefulset.yml
+++ b/templates/node/msa/core-statefulset.yml
@@ -66,6 +66,7 @@ spec:
               value: "tb-core"
             - name: HTTP_LOG_CONTROLLER_ERROR_STACK_TRACE
               value: "false"
+            {{- include "thingsboard.existingSecrets" . | indent 12 }}
           envFrom:
             - configMapRef:
                 name: {{$releaseName}}-node-custom-env

--- a/templates/node/msa/rule-engine-statefulset.yml
+++ b/templates/node/msa/rule-engine-statefulset.yml
@@ -65,6 +65,7 @@ spec:
               value: "tb-rule-engine"
             - name: HTTP_LOG_CONTROLLER_ERROR_STACK_TRACE
               value: "false"
+            {{- include "thingsboard.existingSecrets" . | indent 12 }}
           envFrom:
             - configMapRef:
                 name: {{$releaseName}}-node-custom-env


### PR DESCRIPTION
Introduces initial handling of existing secrets as a source of passwords for internal and external databases and caches.
It does not work in its current state, but this commit may serve as a starting point for a working solution.

addresses #19 