### PR TITLE
Hotfix/fix helpers template

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -160,11 +160,11 @@ Return a transport image
 {{- $transportBody := index . "transportBody" -}}
 {{- if $context.Values.installation.pe }}
 {{- $repository := $transportBody.image.repository | default (printf "thingsboard/tb-pe-%s" $transportBody.name) }}
-{{- $appversion := $transportBody.image.tag | default (printf "%sPE" .Values.global.tag) | default (printf "%sPE" $context.Chart.AppVersion) }}
+{{- $appversion := $transportBody.image.tag | default (printf "%sPE" $context.Values.global.tag) | default (printf "%sPE" $context.Chart.AppVersion) }}
 {{- printf "%s:%s" $repository $appversion }}
 {{- else }}
 {{- $repository := $transportBody.image.repository | default (printf "thingsboard/tb-%s" $transportBody.name) }}
-{{- $appversion := $transportBody.image.tag | default .Values.global.tag | default (printf "%s" $context.Chart.AppVersion) }}
+{{- $appversion := $transportBody.image.tag | default $context.Values.global.tag | default (printf "%s" $context.Chart.AppVersion) }}
 {{- printf "%s:%s" $repository $appversion }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -669,7 +669,7 @@ transports:
     # Name that will be used for kubernetes resources like sts and services
     name: mqtt-transport
     # Enable or disable this transport into your cluster
-    enabled: true
+    enabled: false
     image:
       # Transport custom repository. When blank - default repository will be used
       repository:

--- a/values.yaml
+++ b/values.yaml
@@ -669,7 +669,7 @@ transports:
     # Name that will be used for kubernetes resources like sts and services
     name: mqtt-transport
     # Enable or disable this transport into your cluster
-    enabled: false
+    enabled: true
     image:
       # Transport custom repository. When blank - default repository will be used
       repository:


### PR DESCRIPTION
When enabling a transport, error occurs when accessing .Values.global.tag from inside the dictionary's context. Added $context where needed.