### PR TITLE
0.2.12

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 3.6.0
 description: Helm chart for Thingsboard cluster.
 name: thingsboard-cluster
 type: application
-version: 0.2.11
+version: 0.2.12
 annotations:
   artifacthub.io/category: streaming-messaging
   licenses: Apache-2.0

--- a/templates/integrationexecutor/integration-executor-default-logback-configmap.yml
+++ b/templates/integrationexecutor/integration-executor-default-logback-configmap.yml
@@ -1,13 +1,14 @@
 {{- $namespace := .Release.Namespace -}}
   {{- $releaseName := .Release.Name }}
+{{- if .Values.integrationExecutor.enabled }}
   {{- if and (.Values.installation.msa) (empty .Values.integrationExecutor.existingTBLogbackConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-integration-executor-default-logback-config" $releaseName}}
+  name: {{ printf "%s-ie-default-logback-config" $releaseName}}
   namespace: {{ $namespace }}
   labels:
-    name: {{ printf "%s-integration-executor-default-logback-config" $releaseName}}
+    name: {{ printf "%s-ie-default-logback-config" $releaseName}}
 data:
   logback: |
     <!DOCTYPE configuration>
@@ -27,3 +28,4 @@ data:
         </root>
     </configuration>
   {{- end }}
+    {{- end }}

--- a/templates/integrationexecutor/integration-executor-statefulset.yml
+++ b/templates/integrationexecutor/integration-executor-statefulset.yml
@@ -81,7 +81,7 @@ spec:
             - name: {{ printf "%s-integration-executor-config" $releaseName}}
               mountPath: /config/tb-ie-executor.conf
               subPath: tb-ie-executor.conf
-            - name: {{ printf "%s-integration-executor-logback-config" $releaseName}}
+            - name: {{ printf "%s-ie-default-logback-config" $releaseName}}
               mountPath: /config/logback.xml
               subPath: logback.xml
             - name: {{$releaseName}}-integration-executor-logs
@@ -97,9 +97,9 @@ spec:
             items:
               - key: conf
                 path: tb-vc-executor.conf
-        - name: {{ printf "%s-integration-executor-logback-config" $releaseName}}
+        - name: {{ printf "%s-ie-default-logback-config" $releaseName}}
           configMap:
-            name: {{ ternary (printf "%s-integration-executor-default-logback-config" $releaseName) .Values.integrationExecutor.existingTBLogbackConfigMap  (empty .Values.integrationExecutor.existingTBLogbackConfigMap) }}
+            name: {{ ternary (printf "%s-ie-default-logback-config" $releaseName) .Values.integrationExecutor.existingTBLogbackConfigMap  (empty .Values.integrationExecutor.existingTBLogbackConfigMap) }}
             items:
               - key: logback
                 path: logback.xml

--- a/templates/loadbalancer/aws/http-load-balancer.yml
+++ b/templates/loadbalancer/aws/http-load-balancer.yml
@@ -24,11 +24,11 @@ spec:
   rules:
       - http:
           paths:
-            - path: /api/v1/integrations/*
-              pathType: ImplementationSpecific
+            - path: /api/v1/integrations
+              pathType: Prefix
               backend:
                 service:
-                  name: {{ include "thingsboard.node.host" . }}
+                  name: {{ include "thingsboard.integrationexecutor.label" . }}
                   port:
                     number: 8080
             - path: /api/v1/
@@ -46,14 +46,14 @@ spec:
                   port:
                     number: 8080
             - path: /static/
-              pathType: ImplementationSpecific
+              pathType: Prefix
               backend:
                 service:
                   name: {{ include "thingsboard.web.host" . }}
                   port:
                     number: 8080
             - path: /index.html
-              pathType: ImplementationSpecific
+              pathType: Prefix
               backend:
                 service:
                   name: {{ include "thingsboard.web.host" . }}


### PR DESCRIPTION
  - fix aws ingress routes for integration executor, use prefixes
  - fix kubernetes error on very long name for integration-executor-default-logback-configmap